### PR TITLE
Enable ElevenLabs voiceover

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ KOKORO_VOICES_PATH="models/voices.bin"
 KOKORO_DEFAULT_VOICE="af"
 KOKORO_DEFAULT_SPEED="1.0"
 KOKORO_DEFAULT_LANG="en-us"
+# ElevenLabs Settings
+ELEVEN_API_KEY=""
+ELEVEN_VOICE_ID=""
+ELEVEN_MODEL_ID="eleven_monolingual_v1"
 ```
 Fill in the API keys according to the model you wanted to use.
 
@@ -301,7 +305,7 @@ DatasetDict({
 
 The FAQ should cover the most common errors you could encounter. If you see something new, report it on issues.
 
-Q: Error `src.utils.kokoro_voiceover import KokoroService  # You MUST import like this as this is our custom voiceover service. ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ModuleNotFoundError: No module named 'src'`. <br>
+Q: Error `src.utils.elevenlabs_voiceover import ElevenLabsService  # You MUST import like this. ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ModuleNotFoundError: No module named 'src'`. <br>
 A: Please run `export PYTHONPATH=$(pwd):$PYTHONPATH` when you start a new terminal. <br>
 
 Q: Error `Files not found` <br>

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,3 +96,4 @@ soundfile~=0.13.1
 krippendorff~=0.8.1
 statsmodels~=0.14.4
 opencv-python~=4.11.0
+elevenlabs~=2.7.1

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,2 @@
+from .elevenlabs_voiceover import ElevenLabsService
+from .kokoro_voiceover import KokoroService

--- a/src/utils/elevenlabs_voiceover.py
+++ b/src/utils/elevenlabs_voiceover.py
@@ -1,0 +1,54 @@
+"""ElevenLabs voiceover service for manim_voiceover."""
+import os
+from pathlib import Path
+from manim_voiceover.services.base import SpeechService
+from elevenlabs.client import ElevenLabs
+
+
+class ElevenLabsService(SpeechService):
+    """Speech service using the ElevenLabs API."""
+
+    def __init__(self,
+                 api_key: str = None,
+                 voice_id: str = None,
+                 model_id: str = None,
+                 **kwargs):
+        self.api_key = api_key or os.getenv("ELEVEN_API_KEY")
+        self.voice_id = voice_id or os.getenv("ELEVEN_VOICE_ID", "")
+        self.model_id = model_id or os.getenv("ELEVEN_MODEL_ID", "eleven_monolingual_v1")
+        self.client = ElevenLabs(api_key=self.api_key)
+        super().__init__(**kwargs)
+
+    def generate_from_text(self, text: str, cache_dir: str = None, path: str = None) -> dict:
+        if cache_dir is None:
+            cache_dir = self.cache_dir
+        input_data = {
+            "input_text": text,
+            "service": "elevenlabs",
+            "voice": self.voice_id,
+            "model": self.model_id,
+        }
+        cached_result = self.get_cached_result(input_data, cache_dir)
+        if cached_result is not None:
+            return cached_result
+        if path is None:
+            filename = self.get_audio_basename(input_data) + ".mp3"
+        else:
+            filename = path
+        out_path = Path(cache_dir) / filename
+        os.makedirs(Path(cache_dir), exist_ok=True)
+        audio_iter = self.client.text_to_speech.convert(
+            voice_id=self.voice_id,
+            text=text,
+            model_id=self.model_id,
+            output_format="mp3_44100_128",
+        )
+        with open(out_path, "wb") as f:
+            for chunk in audio_iter:
+                f.write(chunk)
+        json_dict = {
+            "input_text": text,
+            "input_data": input_data,
+            "original_audio": filename,
+        }
+        return json_dict

--- a/task_generator/prompts_raw/__init__.py
+++ b/task_generator/prompts_raw/__init__.py
@@ -1692,7 +1692,7 @@ Scene Technical Implementation:
 
 1.  **Scene Class:** Class name `Scene{scene_number}`, where `{scene_number}` is replaced by the scene number (e.g., `Scene1`, `Scene2`). The scene class should at least inherit from `VoiceoverScene`. However, you can add more Manim Scene classes on top of VoiceoverScene for multiple inheritance if needed.
 2.  **Imports:** Include ALL necessary imports explicitly at the top of the file, based on used Manim classes, functions, colors, and constants. Do not rely on implicit imports. Double-check for required modules, classes, functions, colors, and constants, *ensuring all imports are valid and consistent with the Manim Documentation*.  **Include imports for any used Manim plugins.**
-3.  **Speech Service:** Initialize `KokoroService()`. You MUST import like this: `from src.utils.kokoro_voiceover import KokoroService` as this is our custom voiceover service.
+3.  **Speech Service:** Initialize `ElevenLabsService()`. You MUST import like this: `from src.utils.elevenlabs_voiceover import ElevenLabsService`.
 4.  **Reusable Animations:** Implement functions for each animation sequence to create modular and reusable code. Structure code into well-defined functions, following function definition patterns from Manim Documentation.
 5.  **Voiceover:** Use `with self.voiceover(text="...")` for speech synchronization, precisely matching the narration script and animation timings from the Animation and Narration Plan.
 6.  **Comments:** Add clear and concise comments for complex animations, spatial logic (positioning, arrangements), and object lifecycle management. *Use comments extensively to explain code logic, especially for spatial positioning, animation sequences, and constraint enforcement, mirroring commenting style in Manim Documentation*.  **Add comments to explain the purpose and usage of any Manim plugins.**
@@ -1726,7 +1726,7 @@ Scene Technical Implementation:
 *   **Reusable Object Creation Functions:** Define reusable functions within helper classes for creating specific Manim objects (e.g., `create_axes`, `create_formula_tex`, `create_explanation_text`).
 *   **Clear Comments and Variable Names:** Use clear, concise comments to explain code sections and logic. Employ descriptive variable names (e.g., `linear_function_formula`, `logistic_plot`) for better readability.
 *   **Text Elements:** Create text elements using `Tex` or `MathTex` for formulas and explanations, styling them with `color` and `font_size` as needed.
-*   **Manim Best Practices:** Follow Manim best practices, including using `VoiceoverScene`, `KokoroService`, common Manim objects, animations, relative positioning, and predefined colors.
+ *   **Manim Best Practices:** Follow Manim best practices, including using `VoiceoverScene`, `ElevenLabsService`, common Manim objects, animations, relative positioning, and predefined colors.
 
 You MUST generate the Python code in the following format (from <CODE> to </CODE>):
 <CODE>
@@ -1734,7 +1734,7 @@ You MUST generate the Python code in the following format (from <CODE> to </CODE
 from manim import *
 from manim import config as global_config
 from manim_voiceover import VoiceoverScene
-from src.utils.kokoro_voiceover import KokoroService # You MUST import like this as this is our custom voiceover service.
+from src.utils.elevenlabs_voiceover import ElevenLabsService # Use ElevenLabs for TTS.
 
 # plugins imports, don't change the import statements
 from manim_circuit import *
@@ -1790,7 +1790,7 @@ class Scene{scene_number}(VoiceoverScene, MovingCameraScene):  # Note: You can a
     # Reminder: This scene class is fully self-contained. There is no dependency on the implementation from previous or subsequent scenes.
     def construct(self):
         # Initialize speech service
-        self.set_speech_service(KokoroService())
+        self.set_speech_service(ElevenLabsService())
 
         # Instantiate helper class (as per plan)
         helper = Scene{scene_number}_Helper(self)  # Example: helper = Scene1_Helper(self)

--- a/task_generator/prompts_raw/prompt_code_generation.txt
+++ b/task_generator/prompts_raw/prompt_code_generation.txt
@@ -17,7 +17,7 @@ Scene Technical Implementation:
 
 1.  **Scene Class:** Class name `Scene{scene_number}`, where `{scene_number}` is replaced by the scene number (e.g., `Scene1`, `Scene2`). The scene class should at least inherit from `VoiceoverScene`. However, you can add more Manim Scene classes on top of VoiceoverScene for multiple inheritance if needed.
 2.  **Imports:** Include ALL necessary imports explicitly at the top of the file, based on used Manim classes, functions, colors, and constants. Do not rely on implicit imports. Double-check for required modules, classes, functions, colors, and constants, *ensuring all imports are valid and consistent with the Manim Documentation*.  **Include imports for any used Manim plugins.**
-3.  **Speech Service:** Initialize `KokoroService()`. You MUST import like this: `from src.utils.kokoro_voiceover import KokoroService` as this is our custom voiceover service.
+3.  **Speech Service:** Initialize `ElevenLabsService()`. You MUST import like this: `from src.utils.elevenlabs_voiceover import ElevenLabsService`.
 4.  **Reusable Animations:** Implement functions for each animation sequence to create modular and reusable code. Structure code into well-defined functions, following function definition patterns from Manim Documentation.
 5.  **Voiceover:** Use `with self.voiceover(text="...")` for speech synchronization, precisely matching the narration script and animation timings from the Animation and Narration Plan.
 6.  **Comments:** Add clear and concise comments for complex animations, spatial logic (positioning, arrangements), and object lifecycle management. *Use comments extensively to explain code logic, especially for spatial positioning, animation sequences, and constraint enforcement, mirroring commenting style in Manim Documentation*.  **Add comments to explain the purpose and usage of any Manim plugins.**
@@ -51,7 +51,7 @@ Scene Technical Implementation:
 *   **Reusable Object Creation Functions:** Define reusable functions within helper classes for creating specific Manim objects (e.g., `create_axes`, `create_formula_tex`, `create_explanation_text`).
 *   **Clear Comments and Variable Names:** Use clear, concise comments to explain code sections and logic. Employ descriptive variable names (e.g., `linear_function_formula`, `logistic_plot`) for better readability.
 *   **Text Elements:** Create text elements using `Tex` or `MathTex` for formulas and explanations, styling them with `color` and `font_size` as needed.
-*   **Manim Best Practices:** Follow Manim best practices, including using `VoiceoverScene`, `KokoroService`, common Manim objects, animations, relative positioning, and predefined colors.
+*   **Manim Best Practices:** Follow Manim best practices, including using `VoiceoverScene`, `ElevenLabsService`, common Manim objects, animations, relative positioning, and predefined colors.
 
 You MUST generate the Python code in the following format (from <CODE> to </CODE>):
 <CODE>
@@ -59,7 +59,7 @@ You MUST generate the Python code in the following format (from <CODE> to </CODE
 from manim import *
 from manim import config as global_config
 from manim_voiceover import VoiceoverScene
-from src.utils.kokoro_voiceover import KokoroService # You MUST import like this as this is our custom voiceover service.
+from src.utils.elevenlabs_voiceover import ElevenLabsService # Use ElevenLabs for TTS.
 
 # plugins imports, don't change the import statements
 from manim_circuit import *
@@ -115,7 +115,7 @@ class Scene{scene_number}(VoiceoverScene, MovingCameraScene):  # Note: You can a
     # Reminder: This scene class is fully self-contained. There is no dependency on the implementation from previous or subsequent scenes.
     def construct(self):
         # Initialize speech service
-        self.set_speech_service(KokoroService())
+        self.set_speech_service(ElevenLabsService())
 
         # Instantiate helper class (as per plan)
         helper = Scene{scene_number}_Helper(self)  # Example: helper = Scene1_Helper(self)


### PR DESCRIPTION
## Summary
- add ElevenLabsService for text to speech
- export in utilities
- update prompts to use ElevenLabsService
- document ElevenLabs variables in README
- add elevenlabs dependency

## Testing
- `python -m py_compile src/utils/elevenlabs_voiceover.py`
- `python -m py_compile src/utils/__init__.py`
- `python -m py_compile task_generator/prompts_raw/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687605ca618c832a8e5be70b0f3ab6dd